### PR TITLE
Add support for `HMAC-SHA256` sign_type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - No magic macros
 - Simplified functional interface
 - Added `WechatPay.API.download_fund_flow/3`.
+- Added `WechatPay.API.batch_query_comments/3`.
+- Added support for two sign types: `:md5` and `:sha256`.
 
 ## v0.7.1
 

--- a/lib/wechat_pay/api/api.ex
+++ b/lib/wechat_pay/api/api.ex
@@ -20,7 +20,7 @@ defmodule WechatPay.API do
           {:ok, map} | {:error, Error.t() | HTTPoison.Error.t()}
   def close_order(client, attrs, options \\ []) do
     with {:ok, data} <- HTTPClient.post(client, "pay/closeorder", attrs, options),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end
@@ -50,7 +50,7 @@ defmodule WechatPay.API do
           {:ok, map} | {:error, WechatPay.Error.t() | HTTPoison.Error.t()}
   def place_order(client, attrs, options \\ []) do
     with {:ok, data} <- HTTPClient.post(client, "pay/unifiedorder", attrs, options),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end
@@ -67,7 +67,7 @@ defmodule WechatPay.API do
           {:ok, map} | {:error, WechatPay.Error.t() | HTTPoison.Error.t()}
   def query_order(client, attrs, options \\ []) do
     with {:ok, data} <- HTTPClient.post(client, "pay/orderquery", attrs, options),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end
@@ -131,7 +131,7 @@ defmodule WechatPay.API do
           {:ok, map} | {:error, WechatPay.Error.t() | HTTPoison.Error.t()}
   def query_refund(client, attrs, options \\ []) do
     with {:ok, data} <- HTTPClient.post(client, "pay/refundquery", attrs, options),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end
@@ -169,7 +169,7 @@ defmodule WechatPay.API do
              attrs,
              Keyword.merge([ssl: ssl], options)
            ),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end
@@ -225,7 +225,6 @@ defmodule WechatPay.API do
       cert: ssl.cert |> decode_public(),
       key: ssl.key |> decode_private()
     ]
-    |> IO.inspect()
     |> Enum.reject(fn {_k, v} -> v == nil end)
   end
 end

--- a/lib/wechat_pay/api/api.ex
+++ b/lib/wechat_pay/api/api.ex
@@ -201,6 +201,36 @@ defmodule WechatPay.API do
     HTTPClient.post(client, "payitil/report", attrs, options)
   end
 
+  @doc """
+  Query comments in a batch
+
+  ⚠️ This requires the ssl config is set
+
+  ## Examples
+
+      iex> WechatPay.API.batch_query_comments(%{
+        begin_time: "20190222000000",
+        end_time: "20190224000000",
+        offset: 0
+      })
+      ...> {:ok, data}
+  """
+  @spec batch_query_comments(Client.t(), map, keyword) ::
+          {:ok, String.t()} | {:error, HTTPoison.Error.t()}
+  def batch_query_comments(client, attrs, options \\ []) do
+    # This API only supports signing with `HMAC-SHA256`
+    client = %{client | sign_type: :sha256}
+
+    ssl = client |> load_ssl()
+
+    HTTPClient.download_text(
+      client,
+      "billcommentsp/batchquerycomment",
+      attrs,
+      Keyword.merge([ssl: ssl], options)
+    )
+  end
+
   defp decode_public(nil), do: nil
 
   defp decode_public(pem) do

--- a/lib/wechat_pay/api/http_client.ex
+++ b/lib/wechat_pay/api/http_client.ex
@@ -87,7 +87,7 @@ defmodule WechatPay.API.HTTPClient do
   defp append_ids(data, app_id, mch_id) when is_map(data) do
     data
     |> Map.merge(%{
-      app_id: app_id,
+      appid: app_id,
       mch_id: mch_id
     })
   end

--- a/lib/wechat_pay/client.ex
+++ b/lib/wechat_pay/client.ex
@@ -10,6 +10,7 @@ defmodule WechatPay.Client do
             app_id: nil,
             mch_id: nil,
             api_key: nil,
+            sign_type: :md5,
             ssl: nil
 
   @type t :: %Client{
@@ -17,6 +18,7 @@ defmodule WechatPay.Client do
           app_id: String.t(),
           mch_id: String.t(),
           api_key: String.t(),
+          sign_type: :md5 | :sha256,
           ssl: [
             {:ca_cert, String.t() | nil},
             {:cert, String.t()},

--- a/lib/wechat_pay/helper.ex
+++ b/lib/wechat_pay/helper.ex
@@ -34,7 +34,7 @@ defmodule WechatPay.Helper do
     request_data =
       %{mch_id: mch_id}
       |> HTTPClient.generate_nonce_str()
-      |> HTTPClient.sign(api_key)
+      |> HTTPClient.sign(%{api_key: api_key, sign_type: :md5})
       |> XMLBuilder.to_xml()
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-

--- a/lib/wechat_pay/payment_methods/app.ex
+++ b/lib/wechat_pay/payment_methods/app.ex
@@ -121,7 +121,7 @@ defmodule WechatPay.App do
   """
   @spec generate_pay_request(Client.t(), String.t()) :: map
   def generate_pay_request(client, prepay_id) do
-    %{
+    data = %{
       "appid" => client.app_id,
       "partnerid" => client.mch_id,
       "prepayid" => prepay_id,
@@ -129,11 +129,8 @@ defmodule WechatPay.App do
       "noncestr" => NonceStr.generate(),
       "timestamp" => Integer.to_string(:os.system_time())
     }
-    |> sign(client.api_key)
-  end
 
-  defp sign(data, api_key) do
     data
-    |> Map.merge(%{"sign" => Signature.sign(data, api_key)})
+    |> Map.merge(%{"sign" => Signature.sign(data, client.api_key, client.sign_type)})
   end
 end

--- a/lib/wechat_pay/payment_methods/app.ex
+++ b/lib/wechat_pay/payment_methods/app.ex
@@ -115,6 +115,15 @@ defmodule WechatPay.App do
   defdelegate report(client, attrs, options \\ []), to: API
 
   @doc """
+  Query comments in a batch
+
+  [Official document](https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_99&index=12)
+  """
+  @spec batch_query_comments(Client.t(), map, keyword) ::
+          {:ok, String.t()} | {:error, HTTPoison.Error.t()}
+  defdelegate batch_query_comments(client, attrs, options \\ []), to: API
+
+  @doc """
   Generate pay request info, which is required for the App SDK
 
   [Official document](https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_12&index=2)

--- a/lib/wechat_pay/payment_methods/jsapi.ex
+++ b/lib/wechat_pay/payment_methods/jsapi.ex
@@ -115,6 +115,15 @@ defmodule WechatPay.JSAPI do
   defdelegate report(client, attrs, options \\ []), to: API
 
   @doc """
+  Query comments in a batch
+
+  [Official document](https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=9_17&index=12)
+  """
+  @spec batch_query_comments(Client.t(), map, keyword) ::
+          {:ok, String.t()} | {:error, HTTPoison.Error.t()}
+  defdelegate batch_query_comments(client, attrs, options \\ []), to: API
+
+  @doc """
   Generate pay request info, which is required for the JavaScript API
 
   [Official document](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=7_7&index=6)

--- a/lib/wechat_pay/payment_methods/jsapi.ex
+++ b/lib/wechat_pay/payment_methods/jsapi.ex
@@ -121,18 +121,15 @@ defmodule WechatPay.JSAPI do
   """
   @spec generate_pay_request(Client.t(), String.t()) :: map
   def generate_pay_request(client, prepay_id) do
-    %{
+    data = %{
       "appId" => client.app_id,
       "timeStamp" => Integer.to_string(:os.system_time()),
       "nonceStr" => NonceStr.generate(),
       "package" => "prepay_id=#{prepay_id}",
-      "signType" => "MD5"
+      "signType" => client.sign_type
     }
-    |> sign(client.api_key)
-  end
 
-  defp sign(data, api_key) do
     data
-    |> Map.merge(%{"paySign" => Signature.sign(data, api_key)})
+    |> Map.merge(%{"paySign" => Signature.sign(data, client.api_key, client.sign_type)})
   end
 end

--- a/lib/wechat_pay/payment_methods/native.ex
+++ b/lib/wechat_pay/payment_methods/native.ex
@@ -115,6 +115,15 @@ defmodule WechatPay.Native do
   defdelegate report(client, attrs, options \\ []), to: API
 
   @doc """
+  Query comments in a batch
+
+  [Official document](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_17&index=11)
+  """
+  @spec batch_query_comments(Client.t(), map, keyword) ::
+          {:ok, String.t()} | {:error, HTTPoison.Error.t()}
+  defdelegate batch_query_comments(client, attrs, options \\ []), to: API
+
+  @doc """
   Shorten the URL to reduce the QR image size
 
   [Official document](https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=9_9)

--- a/lib/wechat_pay/payment_methods/native.ex
+++ b/lib/wechat_pay/payment_methods/native.ex
@@ -124,7 +124,7 @@ defmodule WechatPay.Native do
   def shorten_url(client, url, options \\ []) do
     with {:ok, data} <-
            HTTPClient.post(client, "tools/shorturl", %{long_url: URI.encode(url)}, options),
-         :ok <- Signature.verify(data, client.api_key) do
+         :ok <- Signature.verify(data, client.api_key, client.sign_type) do
       {:ok, data}
     end
   end

--- a/lib/wechat_pay/plug/handler.ex
+++ b/lib/wechat_pay/plug/handler.ex
@@ -11,7 +11,7 @@ defmodule WechatPay.Plug.Handler do
 
     @impl WechatPay.Plug.Handler
     def handle_data(conn, data) do
-      # the sign is already verified by `WechatPay.Utils.Signature.verify/2`.
+      # the sign is already verified by `WechatPay.Utils.Signature.verify/3`.
       data = %{
         appid: "wx2421b1c4370ec43b",
         attach: "支付测试",

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "credo": {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.5", "c9c2379c59cf2dfc74690f48866e33ffb55ff660e5e02405c14614d204efdc4f", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "exactor": {:hex, :exactor, "2.2.4", "5efb4ddeb2c48d9a1d7c9b465a6fffdd82300eb9618ece5d34c3334d5d7245b1", [:mix], [], "hexpm"},


### PR DESCRIPTION
- [x] Looks like sandbox does not support HMAC-SHA256 (confirmed works for production)
- [x] Batch query comment API only supports HMAC-SHA256: https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_17&index=11
